### PR TITLE
Fixes spec bug.

### DIFF
--- a/threejs-rails.gemspec
+++ b/threejs-rails.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  gem.add_dependency("railties", ">= 3.0.0")
+  spec.add_dependency("railties", ">= 3.0.0")
 end


### PR DESCRIPTION
There was a (probably) copy/paste bug, the dependency was defined on an
incorrect spec variable.
