### PR TITLE
Change from spermy to gt or = for railties dependency

### DIFF
--- a/threejs-rails.gemspec
+++ b/threejs-rails.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  spec.add_runtime_dependency 'railties', '~> 3.0'
+  spec.add_runtime_dependency 'railties', '>= 3.0'
 end


### PR DESCRIPTION
Hi, not sure if this will be useful for anyone else  but I got a railties version conflict on trying to bundle your gem into my Rails 5.2.0 app. Changing this line allowed me to install it.